### PR TITLE
Update WYPopoverController.m

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -2936,7 +2936,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
 
 #pragma mark Inline functions
 
-static NSString* WYStringFromOrientation(NSInteger orientation) {
+__unused static NSString* WYStringFromOrientation(NSInteger orientation) {
     NSString *result = @"Unknown";
     
     switch (orientation) {


### PR DESCRIPTION
Fixes unused function warning in Xcode.
