### PR TITLE
Fix navigation controller background problem

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -2538,6 +2538,8 @@ static WYPopoverTheme *defaultTheme_ = nil;
         backgroundView.frame = containerFrame;
     }
     
+    [backgroundView setNeedsDisplay];
+    
     WY_LOG(@"popoverContainerView.frame = %@", NSStringFromCGRect(backgroundView.frame));
 }
 


### PR DESCRIPTION
Navigation controller in wypopover does not redraw its background after
view transition. Add setNeedsDisplay in end of -
(void)positionPopover:(BOOL)aAnimated
