### PR TITLE
Respect navigation bar hidden property

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1094,7 +1094,7 @@ static float edgeSizeFromCornerRadius(float cornerRadius) {
     if ([viewController isKindOfClass:[UINavigationController class]])
     {
         UINavigationController* navigationController = (UINavigationController*)viewController;
-        navigationBarHeight = navigationController.navigationBar.bounds.size.height;
+        navigationBarHeight = navigationController.navigationBarHidden? 0 : navigationController.navigationBar.bounds.size.height;
     }
     
     contentView.frame = CGRectIntegral([self innerRect]);


### PR DESCRIPTION
This fixes a SIGABRT crash in WYPopoverBackgroundInnerView's -drawRect: when the content view controller is a UINavigationController, yet the navigation bar is hidden and the content size height is less than or equal to the navigation bar height (44).
