### PR TITLE
Improvements: dismissOnTap and dimissOnPassthroughViewTap properties; optional dismissCompletionBlock

### DIFF
--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -109,6 +109,8 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 
 @property (nonatomic, strong) WYPopoverTheme                   *theme;
 
+@property (nonatomic, copy) void (^dismissCompletionBlock)(WYPopoverController *dimissedController);
+
 + (void)setDefaultTheme:(WYPopoverTheme *)theme;
 + (WYPopoverTheme *)defaultTheme;
 

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -2686,6 +2686,11 @@ static WYPopoverTheme *defaultTheme_ = nil;
         {
             [strongSelf->delegate popoverControllerDidDismissPopover:strongSelf];
         }
+        
+        if (self.dismissCompletionBlock)
+        {
+            self.dismissCompletionBlock(strongSelf);
+        }
     };
     
     if (isListeningNotifications == YES)


### PR DESCRIPTION
- Added options to dismiss on inner tap and dimiss on passthrough tap (`dismissOnTap` and `dimissOnPassthroughViewTap` BOOL properties).
- Added optional `^dismissCompletionBlock(WYPopoverController *dimissedController`) block property. Can be used in addition to, or in place of, the delegate's `popoverControllerDidDismissPopover:` method.
- Removed old unused touch code
