### PR TITLE
Added the ability to perform certain actions without implicit animations

### DIFF
--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -104,6 +104,7 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 @property (nonatomic, strong, readonly) UIViewController       *contentViewController;
 @property (nonatomic, assign) CGSize                            popoverContentSize;
 @property (nonatomic, assign) float                             animationDuration;
+@property (nonatomic, assign) BOOL                              implicitAnimationsDisabled;
 
 @property (nonatomic, strong) WYPopoverTheme                   *theme;
 
@@ -194,6 +195,11 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 - (void)dismissPopoverAnimated:(BOOL)animated
                        options:(WYPopoverAnimationOptions)aOptions
                     completion:(void (^)(void))completion;
+
+// Misc
+
+- (void)setPopoverContentSize:(CGSize)size animated:(BOOL)animated;
+- (void)performWithoutAnimation:(void (^)(void))aBlock;
 
 @end
 

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1908,6 +1908,21 @@ static WYPopoverTheme *defaultTheme_ = nil;
     [self positionPopover:YES];
 }
 
+- (void)setPopoverContentSize:(CGSize)size animated:(BOOL)animated
+{
+    popoverContentSize_ = size;
+    [self positionPopover:animated];
+}
+
+- (void)performWithoutAnimation:(void (^)(void))aBlock
+{
+    if (aBlock) {
+        self.implicitAnimationsDisabled = YES;
+        aBlock();
+        self.implicitAnimationsDisabled = NO;
+    }
+}
+
 - (void)presentPopoverFromRect:(CGRect)aRect
                         inView:(UIView *)aView
       permittedArrowDirections:(WYPopoverArrowDirection)aArrowDirections
@@ -2604,7 +2619,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
     
     containerFrame.origin = WYPointRelativeToOrientation(containerOrigin, containerFrame.size, orientation);
 
-    if (aAnimated == YES) {
+    if (aAnimated == YES && !self.implicitAnimationsDisabled) {
         backgroundView.frame = savedContainerFrame;
         __weak __typeof__(self) weakSelf = self;
         [UIView animateWithDuration:0.10f animations:^{
@@ -2745,7 +2760,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
     }
     @catch (NSException * __unused exception) {}
     
-    if (aAnimated)
+    if (aAnimated && !self.implicitAnimationsDisabled)
     {
         [UIView animateWithDuration:duration animations:^{
             __typeof__(self) strongSelf = weakSelf;


### PR DESCRIPTION
Like replacing a view inside the contentViewController that would normally cause the background frame to change and animate.

See https://github.com/sammcewan/WYPopoverController/issues/32
