### PR TITLE
Fix potential retain cycle with inView ivar

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -2814,6 +2814,9 @@ static WYPopoverTheme *defaultTheme_ = nil;
             
             [strongSelf->overlayView removeFromSuperview];
             strongSelf->overlayView = nil;
+
+            // inView is captured strongly in presentPopoverInRect:... method, so it needs to be released in dismiss method to avoid potential retain cycles
+            strongSelf->inView = nil;
         }
         
         if (completion)


### PR DESCRIPTION
Hi, @sammcewan 
Thanks a lot for supporting this component, it's really helpful and convenient in use.

But I found a possible memory issue that might appear in some cases.

For example, if popover controller should be presented from a view, retain cycle may occur:

```MyView``` creates popover, holds strong reference to ```WYPopoverController```, and calls 
```-(void)presentPopoverInRect:rect inView:self ...``` method. 

At this moment, WYPopoverController assigns strong reference of ```MYView```  to ```inView``` ivar. But this leads to retain cycle and ```MYView``` and ```WYPopoverController``` instances will never deallocated. 

Adding ```__weak``` attribute to ```inView``` ivar can lead to crashes when popover is still presented but ```inView``` is already deallocated, 
So it seems that solution to breaking retain cycle is to assign ```inView = nil``` in 
```-(void)dismissPopover``` method.

Thanks!