### PR TITLE
Added alpha theme property to the pop over

### DIFF
--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -92,6 +92,8 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 
 @property (nonatomic, strong) UIColor *overlayColor                         UI_APPEARANCE_SELECTOR;
 
+@property(nonatomic) CGFloat preferredAlpha                                 UI_APPEARANCE_SELECTOR;
+
 @end
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -266,6 +268,8 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 @property (nonatomic, assign) UIEdgeInsets viewContentInsets;
 
 @property (nonatomic, strong) UIColor *overlayColor;
+
+@property (nonatomic) CGFloat preferredAlpha;
 
 + (instancetype)theme;
 + (instancetype)themeForIOS6;

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -443,6 +443,8 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
   result.innerCornerRadius = 6;
   result.viewContentInsets = UIEdgeInsetsMake(3, 0, 0, 0);
   result.overlayColor = [UIColor clearColor];
+  result.preferredAlpha = 1.0f;
+
 
   return result;
 }
@@ -475,6 +477,8 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
   result.innerCornerRadius = 0;
   result.viewContentInsets = UIEdgeInsetsZero;
   result.overlayColor = [UIColor colorWithWhite:0 alpha:0.15];
+  result.preferredAlpha = 1.0f;
+
 
   return result;
 }
@@ -970,7 +974,9 @@ static float edgeSizeFromCornerRadius(float cornerRadius) {
   [super setNeedsDisplay];
 
   [self.layer setNeedsDisplay];
-
+    
+  self.alpha = self.preferredAlpha;
+    
   if (_innerView) {
     _innerView.gradientTopColor = self.fillTopColor;
     _innerView.gradientBottomColor = self.fillBottomColor;
@@ -1495,6 +1501,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
     appearance.innerCornerRadius = aTheme.innerCornerRadius;
     appearance.viewContentInsets = aTheme.viewContentInsets;
     appearance.overlayColor = aTheme.overlayColor;
+    appearance.preferredAlpha = aTheme.preferredAlpha;
   }
 }
 
@@ -1546,6 +1553,8 @@ static WYPopoverTheme *defaultTheme_ = nil;
     _theme.innerCornerRadius = appearance.innerCornerRadius;
     _theme.viewContentInsets = appearance.viewContentInsets;
     _theme.overlayColor = appearance.overlayColor;
+    _theme.preferredAlpha = appearance.preferredAlpha;
+
 
     themeIsUpdating = NO;
     themeUpdatesEnabled = YES;
@@ -1623,6 +1632,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
     _backgroundView.innerShadowOffset = _theme.innerShadowOffset;
     _backgroundView.innerCornerRadius = _theme.innerCornerRadius;
     _backgroundView.viewContentInsets = _theme.viewContentInsets;
+    _backgroundView.preferredAlpha = _theme.preferredAlpha;
     [_backgroundView setNeedsDisplay];
   }
 
@@ -1860,7 +1870,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
 
       if (strongSelf) {
         strongSelf->_overlayView.alpha = 1;
-        strongSelf->_backgroundView.alpha = 1;
+        strongSelf->_backgroundView.alpha = strongSelf->_backgroundView.preferredAlpha;
         strongSelf->_backgroundView.transform = endTransform;
       }
       adjustTintDimmed();


### PR DESCRIPTION
I needed to show a popover with an alpha lower that 1.0f. Added this property to the theme - this is being set independently of the popover presenting animation being "enabled" (the appearing animation now goes from 0.0f to the chosen alpha and vice-versa).

Thanks and please keep up your good work! :)