### PR TITLE
Fixed loop bug

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -341,7 +341,7 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
     if ([self.navigationController wy_isEmbedInPopover] == NO) {
       return;
     } else if ([self respondsToSelector:@selector(setPreferredContentSize:)]) {
-      [self.navigationController setPreferredContentSize:aSize];
+      [self.navigationController sizzled_setPreferredContentSize:aSize];
     }
 #endif
   }


### PR DESCRIPTION
Actually calling `setPreferredContentSize` calls the swizzled implementation (itself) and results in an endless loop. Calling `sizzled_setPreferredContentSize` will call the original method and set the content size properly.