### PR TITLE
Fix for incorrect UIInterfaceOrientation evaluation warning

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -2733,7 +2733,7 @@ static float WYStatusBarHeight() {
     CGRect statusBarFrame = [[UIApplication sharedApplication] statusBarFrame];
     statusBarHeight = statusBarFrame.size.height;
 
-    if (UIDeviceOrientationIsLandscape(orientation))
+    if (UIInterfaceOrientationIsLandscape(orientation))
     {
       statusBarHeight = statusBarFrame.size.width;
     }


### PR DESCRIPTION
Fixing an incorrect comparison between UIInterfaceOrientation and UIDeviceOrientation values (shows up as a warning in the latest betas of Xcode).