### PR TITLE
Modified code that deals with repositioning popover on orientation change

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -2855,21 +2855,18 @@ static CGPoint WYPointRelativeToOrientation(CGPoint origin, CGSize size, UIInter
     _inView = [_barButtonItem valueForKey:@"view"];
     _rect = _inView.bounds;
   } else if ([_delegate respondsToSelector:@selector(popoverController:willRepositionPopoverToRect:inView:)]) {
-    CGRect anotherRect;
-    UIView *anotherInView;
+    CGRect anotherRect = CGRectZero;
+    UIView *anotherInView = nil;
 
     [_delegate popoverController:self willRepositionPopoverToRect:&anotherRect inView:&anotherInView];
 
-#pragma clang diagnostic push
-#pragma GCC diagnostic ignored "-Wtautological-pointer-compare"
-    if (&anotherRect != NULL) {
+    if (!CGRectEqualToRect(anotherRect, CGRectZero)) {
       _rect = anotherRect;
     }
 
-    if (&anotherInView != NULL) {
+    if (anotherInView != nil) {
       _inView = anotherInView;
     }
-#pragma GCC diagnostic pop
   }
 
   [self positionPopover:NO];


### PR DESCRIPTION
The code that existed after calling the delegate's willRepositionPopoverToRect method was incorrectly comparing pointers -- the code had #pragmas around it to stop the compiler warning, but it was a valid warning - the code wasn't doing what was intended.  Changed this block to initialize the local variables passed by reference to the delete method, and then correctly check values that may have been returned.  Made the assumption that if you pass in CGRectZero for the bounds, then a valid change in bounds would not be CGRectZero (seems reasonable).