### PR TITLE
Attempt to fix popover rotation

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -2863,7 +2863,7 @@ static CGPoint WYPointRelativeToOrientation(CGPoint origin, CGSize size, UIInter
   
   WY_LOG(@"Queue change to orientation %@ with frame %@", WYStringFromOrientation(orientation), NSStringFromCGRect(orientationFrame));
   
-  dispatch_sync(orientationSyncQueue, ^{
+  dispatch_async(orientationSyncQueue, ^{
     
     WY_LOG(@"Will change to orientation %@", WYStringFromOrientation(orientation));
     

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1428,7 +1428,6 @@ static float edgeSizeFromCornerRadius(float cornerRadius) {
   BOOL                     _animated;
   BOOL                     _isListeningNotifications;
   BOOL                     _isObserverAdded;
-  BOOL                     _isInterfaceOrientationChanging;
   BOOL                     _ignoreOrientation;
   __weak UIBarButtonItem  *_barButtonItem;
 


### PR DESCRIPTION
This is a small change, can sounds like an hack but i don't think it is.

I thinks you could use only the `UIApplicationDidChangeStatusBarOrientationNotification` to change the popover rotation since this is fired always.
From my point of view, the device orientation, it is all the information from the accelerometer, gyroscope and all that stuff, if it is face down, face up, isn't needed to this.
Anyway, i left there the notification.

I decide to merge both notification in the same callback and use a queue to sync the rotation.
At least, for our problem it seems to fix the problem and it's working like a charm.

Check it as soon as possible, and let us know what you think about this.

Many thanks.
