### PR TITLE
Add support for app extensions

### DIFF
--- a/WYPopoverController.podspec
+++ b/WYPopoverController.podspec
@@ -11,9 +11,17 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => 'https://github.com/sammcewan/WYPopoverController.git', :tag => '0.3.8' }
 
-  s.source_files = 'WYPopoverController/*.{h,m}'
   s.requires_arc = true
 
   s.ios.deployment_target = '6.0'
-  s.ios.frameworks = 'QuartzCore', 'UIKit', 'CoreGraphics'
+
+  s.subspec 'Core' do |core|
+  core.source_files = 'WYPopoverController/*.{h,m}'
+    core.frameworks = 'QuartzCore', 'UIKit', 'CoreGraphics'
+  end
+
+  s.subspec 'AppExtension' do |app_extension|
+    app_extension.dependency 'WYPopoverController/Core'
+    app_extension.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) WY_APP_EXTENSIONS=1' }
+  end
 end


### PR DESCRIPTION
WYPopover currently doesn't compile on iOS extensions.

A workaround is to wrap every forbidden call into a `#if !defined(WY_APP_EXTENSIONS)` macro. This is used in most libraries.

I've been using this fix in production for a few weeks already, it works very well.
