### PR TITLE
Fix bug can't change the content size of a popover

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -341,7 +341,7 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
     if ([self.navigationController wy_isEmbedInPopover] == NO) {
       return;
     } else if ([self respondsToSelector:@selector(setPreferredContentSize:)]) {
-      [self.navigationController sizzled_setPreferredContentSize:aSize];
+      [self.navigationController setPreferredContentSize:aSize];
     }
 #endif
   }


### PR DESCRIPTION
Fix bug we can't change the content size of a popover when call `self.preferredContentSize = ...`
![wypopovercontroller](https://cloud.githubusercontent.com/assets/10323871/12704031/61c3fca4-c884-11e5-96d5-c65f071d6bbc.gif)
